### PR TITLE
Anchored URIs in the HTML results

### DIFF
--- a/sparqlbin.js
+++ b/sparqlbin.js
@@ -139,7 +139,11 @@ function renderResults(data){
 			else buffer += "<tr class='invrow'>";
 			for(rvar in data.head.vars) { // iterate over columns per row
 				var col = data.head.vars[rvar];
-				buffer += "<td>" + data.results.bindings[entry][col].value + "</td>";
+				var result = data.results.bindings[entry][col].value;
+				if(result.indexOf("http") == 0) // if the result is an URI
+					buffer += "<td><a href='" + result + "' target='_blank'>" + result + "</a></td>";
+				else
+					buffer += "<td>" + result + "</td>";
 			}
 			buffer += "</tr>";
 		}

--- a/sparqlbin.js
+++ b/sparqlbin.js
@@ -140,7 +140,7 @@ function renderResults(data){
 			for(rvar in data.head.vars) { // iterate over columns per row
 				var col = data.head.vars[rvar];
 				var result = data.results.bindings[entry][col].value;
-				if(result.indexOf("http") == 0) // if the result is an URI
+				if(data.results.bindings[entry][col].type == 'uri') // if the result is an URI
 					buffer += "<td><a href='" + result + "' target='_blank'>" + result + "</a></td>";
 				else
 					buffer += "<td>" + result + "</td>";


### PR DESCRIPTION
Hi Michael, I added a little change in the `sparqlbin.js` file, which generates anchor tags in the HTML for the results which are of URI type. This way, it would be easier to reach the Linked Data entities (classes, objects, properties) directly from the result set.
